### PR TITLE
Passing provided attributes to SVG tag

### DIFF
--- a/lib/action_view/use/helpers.rb
+++ b/lib/action_view/use/helpers.rb
@@ -3,11 +3,11 @@
 module ActionView
   module Use
     module Helpers
-      def use_symbol(name)
+      def use_symbol(name, escape: true, **opts)
         used_symbol_set << name
 
         <<~HTML.html_safe
-          <svg xmlns="http://www.w3.org/2000/svg">
+          <svg xmlns="http://www.w3.org/2000/svg" #{tag_builder.tag_options(opts, escape)}>
             <use href="##{name}" />
           </svg>
         HTML

--- a/test/action_view/use/helpers_test.rb
+++ b/test/action_view/use/helpers_test.rb
@@ -73,5 +73,13 @@ module ActionView::Use
         </svg>
       HTML
     end
+
+    test "use_symbol will use provided attributes" do
+      assert_dom_equal <<~HTML, use_symbol("icons/home", class: "some-class", hidden: true)
+        <svg xmlns="http://www.w3.org/2000/svg" class="some-class" hidden="hidden">
+          <use href="#icons/home" />
+        </svg>
+      HTML
+    end
   end
 end


### PR DESCRIPTION
Currently, there is no way to pass HTML attributes to the SVG tag. However, there are some attributes and styles that need to be on the SVG tag directly. 

For example, `height` and `width` have to be specified on the tag itself, otherwise it will result in the SVG taking 300px x 150px.

This PR would ensure that we can pass the necessary styles to the underlying SVG tag.